### PR TITLE
Force python rootdir to be tests_files dir

### DIFF
--- a/autocheck/__main__.py
+++ b/autocheck/__main__.py
@@ -35,7 +35,7 @@ def main():
     input_json_file: InputJSON = get_input_file()
     exercise_data: Exercise = get_exercise_from_input(input_json_file)
     tests: List[str] = get_tests_to_run(exercise_data)
-    pytest.main(tests)
+    pytest.main(["--rootdir", TESTS_FILES_DIRECTORY] + tests)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes sure that the `conftest.py` in this repo is always run no matter the tests run