### PR TITLE
Add option to pytest to allow logging traces to appear in tests

### DIFF
--- a/autocheck/__main__.py
+++ b/autocheck/__main__.py
@@ -42,7 +42,7 @@ def main():
     input_json_file: InputJSON = get_input_file()
     exercise_data: Exercise = get_exercise_from_input(input_json_file)
     tests: List[str] = get_tests_to_run(exercise_data)
-    pytest.main(["--rootdir", TESTS_FILES_DIRECTORY] + tests)
+    pytest.main(["--rootdir", TESTS_FILES_DIRECTORY, "-o", "log_cli=1"] + tests)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This kind of weird - giving ini file config as command line option to pytest, but I think it's okay